### PR TITLE
Added support for a single command line argument

### DIFF
--- a/graffle.sh
+++ b/graffle.sh
@@ -8,6 +8,10 @@ elif [ $# -eq 3 ]; then
     FORMAT=$1
     INPUT_FILE=$2
     OUTPUT_FILE=$3
+elif [ $# -eq 1 ]; then
+    FORMAT=""
+    INPUT_FILE=$1
+    OUTPUT_FILE=`echo ${INPUT_FILE} | sed 's/\.graffle$/.pdf/'`;
 else
     PROG=`basename $0`
     echo "Usage: $PROG [<format>] <graffle file> <outputfile>"


### PR DESCRIPTION
If there is only one command line argument, it will be
considered to be the input file, and the output file will
be the input file with the extension of .graffle changed
to .pdf.

The reason for adding support for this is that I can
have Hazel run this script on any changed .graffle
files in my repository and automatically create the
corresponding PDF files without manual intervention.
